### PR TITLE
Keeping csv header order

### DIFF
--- a/csv_diff.cpp
+++ b/csv_diff.cpp
@@ -45,6 +45,11 @@ int main(int argc, char** argv) {
         use_data_names = true;
     }
 
+    bool group_by_result = false;
+    if (opts->HasFlag("--group")) {
+        group_by_result = true;
+    }
+
     // Read CsvFile instances from input files
     auto files = opts->GetParams();
     auto refFile = std::make_shared<CsvFile>(files[0]);
@@ -57,6 +62,7 @@ int main(int argc, char** argv) {
     compare->SetHideNan(hide_nan);
     compare->SetMatchColumns(match_columns);
     compare->SetUseDataNames(use_data_names);
+    compare->SetGroupByResult(group_by_result);
     compare->SetRefFile(refFile);
     compare->SetDataFile(dataFile);
     compare->Run();

--- a/inc/CsvDiff.hpp
+++ b/inc/CsvDiff.hpp
@@ -23,6 +23,7 @@ private:
     bool hide_same_;
     bool hide_nan_;
     bool use_data_names_;
+    bool group_by_result_;
     CsvFilePtr ref_;
     CsvFilePtr data_;
     std::unique_ptr<CsvReport> report_;
@@ -33,6 +34,7 @@ public:
         match_ = false;
         hide_same_ = false;
         hide_nan_ = false;
+        group_by_result_ = false;
     }
     ~CsvDiff() {}
     void SetEpsilon(const double& eps) {
@@ -49,6 +51,9 @@ public:
     }
     void SetUseDataNames(const bool use) {
         use_data_names_ = use;
+    }
+    void SetGroupByResult(const bool group) {
+        group_by_result_ = group;
     }
     void SetRefFile(CsvFilePtr ref) {
         ref_ = ref;
@@ -74,6 +79,7 @@ public:
         report_->SetEpsilon(eps_);
         report_->SetHideSame(hide_same_);
         report_->SetHideNan(hide_nan_);
+        report_->SetGroupByResult(group_by_result_);
         report_->Init();
 
         // Get names for columns with matching names in both input files.

--- a/inc/CsvReport.hpp
+++ b/inc/CsvReport.hpp
@@ -13,6 +13,7 @@ class CsvReport {
 private:
     bool hide_same_;
     bool hide_nan_;
+    bool group_by_result_;
     size_t same_count_;
     size_t nan_count_;
     double eps_ = std::numeric_limits<double>::quiet_NaN();
@@ -29,6 +30,7 @@ public:
     CsvReport() {
         hide_same_ = false;
         hide_nan_ = false;
+        group_by_result_ = false;
         same_count_ = 0;
         nan_count_ = 0;
     }
@@ -41,6 +43,9 @@ public:
     }
     void SetHideNan(const bool hide) {
         hide_nan_ = hide;
+    }
+    void SetGroupByResult(const bool group) {
+        group_by_result_ = group;
     }
     void Init() {
         lines_.clear();
@@ -124,7 +129,9 @@ public:
             std::cout << "\n";
         }
 
-        std::sort(var_lines_.begin(), var_lines_.end());
+        if (group_by_result_) {
+            std::sort(var_lines_.begin(), var_lines_.end());
+        }
         for (const auto& line : var_lines_) {
             lines_.push_back(line.substr(3));
         }


### PR DESCRIPTION
- (--group) option added to keeping order or not.
- By default grouping in report is made optional.